### PR TITLE
Adding panicif.Nil and panicif.NotNIl + go.mod + go.sum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/alexbyk/panicif
+
+go 1.13
+
+require github.com/alexbyk/ftest v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/alexbyk/ftest v1.0.2 h1:iGl/zMF9pPSTAFZaQa0HQQElZ2lsoBeWfh2DJ474OGc=
+github.com/alexbyk/ftest v1.0.2/go.mod h1:qx6SHyYLp2Lg02WaK4t0hY2z1gt03T0rgKRcFj1YPWk=

--- a/panicif.go
+++ b/panicif.go
@@ -14,6 +14,7 @@ package panicif
 
 import (
 	"fmt"
+	"reflect"
 )
 
 // Err panics with a given argument if the argument isn't nil
@@ -39,14 +40,26 @@ func False(cond bool, format string, a ...interface{}) {
 
 // Nil panics if the first argument is Nil
 func Nil(val interface{}, format string, a ...interface{}) {
-	if val == nil {
+	if isNil(val) {
 		panic(fmt.Errorf(format, a...))
 	}
 }
 
 // NotNil panics if the first argument is Nil
 func NotNil(val interface{}, format string, a ...interface{}) {
-	if val != nil {
+	if !isNil(val) {
 		panic(fmt.Errorf(format, a...))
 	}
+}
+
+func isNil(v interface{}) bool {
+	return v == nil || isNilable(v) && reflect.ValueOf(v).IsNil()
+}
+
+func isNilable(v interface{}) bool {
+	switch reflect.TypeOf(v).Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
+		return true
+	}
+	return false
 }

--- a/panicif.go
+++ b/panicif.go
@@ -36,3 +36,17 @@ func False(cond bool, format string, a ...interface{}) {
 		panic(fmt.Errorf(format, a...))
 	}
 }
+
+// Nil panics if the first argument is Nil
+func Nil(val interface{}, format string, a ...interface{}) {
+	if val == nil {
+		panic(fmt.Errorf(format, a...))
+	}
+}
+
+// NotNil panics if the first argument is Nil
+func NotNil(val interface{}, format string, a ...interface{}) {
+	if val != nil {
+		panic(fmt.Errorf(format, a...))
+	}
+}

--- a/panicif_test.go
+++ b/panicif_test.go
@@ -24,3 +24,15 @@ func Test_False(t *testing.T) {
 	ft.PanicsSubstr(func() { panicif.False(false, "Foo") }, "Foo")
 	ft.PanicsSubstr(func() { panicif.False(false, "Foo %s", "bar") }, "Foo bar")
 }
+
+func Test_Nil(t *testing.T) {
+	ft := ftest.New(t)
+	ft.PanicsSubstr(func() { panicif.Nil(nil, "Foo") }, "Foo")
+	ft.PanicsSubstr(func() { panicif.Nil(nil, "Foo %s", "bar") }, "Foo bar")
+}
+
+func Test_NotNil(t *testing.T) {
+	ft := ftest.New(t)
+	ft.PanicsSubstr(func() { panicif.NotNil(true, "Foo") }, "Foo")
+	ft.PanicsSubstr(func() { panicif.NotNil(false, "Foo %s", "bar") }, "Foo bar")
+}

--- a/panicif_test.go
+++ b/panicif_test.go
@@ -27,12 +27,31 @@ func Test_False(t *testing.T) {
 
 func Test_Nil(t *testing.T) {
 	ft := ftest.New(t)
+	var foo interface{}
+	ft.PanicsSubstr(func() { panicif.Nil(foo, "Foo") }, "Foo")
 	ft.PanicsSubstr(func() { panicif.Nil(nil, "Foo") }, "Foo")
+	ft.PanicsSubstr(func() { panicif.Nil((*struct{})(nil), "Foo") }, "Foo")
 	ft.PanicsSubstr(func() { panicif.Nil(nil, "Foo %s", "bar") }, "Foo bar")
 }
 
 func Test_NotNil(t *testing.T) {
 	ft := ftest.New(t)
-	ft.PanicsSubstr(func() { panicif.NotNil(true, "Foo") }, "Foo")
+	var foo interface{}
+	foo = 33
+
+	ft.PanicsSubstr(func() { panicif.NotNil(foo, "Foo") }, "Foo")
+	ft.PanicsSubstr(func() { panicif.NotNil(&struct{}{}, "Foo") }, "Foo")
+	ft.PanicsSubstr(func() { panicif.NotNil("not nill", "Foo") }, "Foo")
+
+	foo = nil
+	var err interface{}
+	func() {
+		defer func() {
+			err = recover()
+		}()
+		panicif.NotNil(foo, "Foo")
+		panicif.NotNil((*struct{})(nil), "Foo")
+	}()
+	ft.Nil(err)
 	ft.PanicsSubstr(func() { panicif.NotNil(false, "Foo %s", "bar") }, "Foo bar")
 }


### PR DESCRIPTION
This adds:

```golang
panicif.Nil(...)
panicif.NotNil(...)
```

It also adds a go.mod which will require go 1.11+ but if you feel strongly about it, you can run `go mod vendor` to support older go versions.